### PR TITLE
Zero structure on test start, avoids occasional test failure

### DIFF
--- a/webgetApp/src/webget_tests.cc
+++ b/webgetApp/src/webget_tests.cc
@@ -27,6 +27,7 @@ namespace {
     TEST(Webget, test_GIVEN_data_THEN_check_encoded_ok){
         // GIVEN
 		aSubRecord rec;
+        memset(&rec, 0, sizeof(rec));
 		rec.ftva = menuFtypeCHAR;
 		rec.nova = 256;
 		rec.vala = new char[rec.nova];


### PR DESCRIPTION
Zero structure (as epics would do), avoids occasional test failure (though these only seem to occur on 32bit builds)