### PR TITLE
Fix bug when updating names and emails

### DIFF
--- a/webgetApp/src/webFormURLEncode.cpp
+++ b/webgetApp/src/webFormURLEncode.cpp
@@ -24,14 +24,14 @@
 /// encode a string as part of building a form urlencoded request
 static std::string getEncodedString(CURL *curl, void* arg1, short type1, int len1, void* arg2, short type2, int len2)
 {
-	const char* s1 = getString(arg1, type1, len1);
-	const char* s2 = getString(arg2, type2, len2);
-	if (s1 == NULL || s2 == NULL)
+	std::string s1 = getString(arg1, type1, len1);
+	std::string s2 = getString(arg2, type2, len2);
+	if (s1.size() == 0 || s2.size() == 0)
 	{
 		return "";
 	}
-	char* es1 = curl_easy_escape(curl, s1, 0);
-	char* es2 = curl_easy_escape(curl, s2, 0);
+	char* es1 = curl_easy_escape(curl, s1.c_str(), 0);
+	char* es2 = curl_easy_escape(curl, s2.c_str(), 0);
 	if (es1 == NULL || es2 == NULL)
 	{
 		return "";

--- a/webgetApp/src/webFormURLEncode.cpp
+++ b/webgetApp/src/webFormURLEncode.cpp
@@ -83,14 +83,14 @@ long webFormURLEncode(aSubRecord *prec)
          errlogPrintf("%s curl init error", prec->name);
 		 return -1;		
 	}
-	addEncodedString(curl, result, prec->a , prec->fta, prec->noa, prec->b, prec->ftb, prec->nob);
-	addEncodedString(curl, result, prec->c , prec->ftc, prec->noc, prec->d, prec->ftd, prec->nod);
-	addEncodedString(curl, result, prec->e , prec->fte, prec->noe, prec->f, prec->ftf, prec->nof);
-	addEncodedString(curl, result, prec->g , prec->ftg, prec->nog, prec->h, prec->fth, prec->noh);
-	addEncodedString(curl, result, prec->i , prec->fti, prec->noi, prec->j, prec->ftj, prec->noj);
-	addEncodedString(curl, result, prec->k , prec->ftk, prec->nok, prec->l, prec->ftl, prec->nol);
-	addEncodedString(curl, result, prec->m , prec->ftm, prec->nom, prec->n, prec->ftn, prec->non);
-	addEncodedString(curl, result, prec->o , prec->fto, prec->noo, prec->p, prec->ftp, prec->nop);
+	addEncodedString(curl, result, prec->a , prec->fta, prec->nea, prec->b, prec->ftb, prec->neb);
+	addEncodedString(curl, result, prec->c , prec->ftc, prec->nec, prec->d, prec->ftd, prec->ned);
+	addEncodedString(curl, result, prec->e , prec->fte, prec->nee, prec->f, prec->ftf, prec->nef);
+	addEncodedString(curl, result, prec->g , prec->ftg, prec->neg, prec->h, prec->fth, prec->neh);
+	addEncodedString(curl, result, prec->i , prec->fti, prec->nei, prec->j, prec->ftj, prec->nej);
+	addEncodedString(curl, result, prec->k , prec->ftk, prec->nek, prec->l, prec->ftl, prec->nel);
+	addEncodedString(curl, result, prec->m , prec->ftm, prec->nem, prec->n, prec->ftn, prec->nen);
+	addEncodedString(curl, result, prec->o , prec->fto, prec->neo, prec->p, prec->ftp, prec->nep);
 	curl_easy_cleanup(curl);
 	strncpy((char*)prec->vala, result.c_str(), prec->nova);
 	prec->neva = (result.size() < prec->nova ? result.size() + 1: prec->nova); // +1 to include NULL

--- a/webgetApp/src/webPOSTRequest.cpp
+++ b/webgetApp/src/webPOSTRequest.cpp
@@ -43,21 +43,21 @@ static size_t write_callback(char *ptr, size_t size, size_t nmemb, void *userdat
 static int webPOSTRequestThreadImp(aSubRecord* prec) 
 {
     static bool debug = (getenv("WEBGET_POST_DEBUG") != NULL ? true : false);
-	const char* url = getString(prec->a, prec->fta, prec->noa);
-	const char* urlEncodedFormData = getString(prec->b, prec->ftb, prec->nob); /* from webFormURLEncode() */
+	std::string url = getString(prec->a, prec->fta, prec->noa);
+	std::string urlEncodedFormData = getString(prec->b, prec->ftb, prec->nob); /* from webFormURLEncode() */
 	CURL *curl = curl_easy_init();
 	if (curl == NULL)
 	{
          errlogPrintf("%s curl init error", prec->name);
 		 return 1;
 	}
-	if (url == NULL || urlEncodedFormData == NULL)
+	if (url.size() == 0 || urlEncodedFormData.size() == 0)
 	{
          errlogPrintf("%s input args A or B are invalid", prec->name);
 		 return 1;
 	}
-	curl_easy_setopt(curl, CURLOPT_URL, url);
-	curl_easy_setopt(curl, CURLOPT_POSTFIELDS, urlEncodedFormData);
+	curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+	curl_easy_setopt(curl, CURLOPT_POSTFIELDS, urlEncodedFormData.c_str());
 	curl_easy_setopt(curl, CURLOPT_USERAGENT, "libcurl-agent/1.0");
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
 	curl_easy_setopt(curl, CURLOPT_WRITEDATA, prec);	
@@ -71,7 +71,7 @@ static int webPOSTRequestThreadImp(aSubRecord* prec)
 	    std::cerr << prec->name << ": POSTing data to URL \"" << url << "\"" << std::endl;
     }
 	CURLcode res;
-	if (!strcmp(url, "test"))
+	if (url == "test")
 	{
 	    std::cerr << prec->name << ": TESTING: ignoring url" << std::endl;
 		res = CURLE_OK;

--- a/webgetApp/src/webPOSTRequest.cpp
+++ b/webgetApp/src/webPOSTRequest.cpp
@@ -43,8 +43,8 @@ static size_t write_callback(char *ptr, size_t size, size_t nmemb, void *userdat
 static int webPOSTRequestThreadImp(aSubRecord* prec) 
 {
     static bool debug = (getenv("WEBGET_POST_DEBUG") != NULL ? true : false);
-	std::string url = getString(prec->a, prec->fta, prec->noa);
-	std::string urlEncodedFormData = getString(prec->b, prec->ftb, prec->nob); /* from webFormURLEncode() */
+	std::string url = getString(prec->a, prec->fta, prec->nea);
+	std::string urlEncodedFormData = getString(prec->b, prec->ftb, prec->neb); /* from webFormURLEncode() */
 	CURL *curl = curl_easy_init();
 	if (curl == NULL)
 	{

--- a/webgetApp/src/webUtils.h
+++ b/webgetApp/src/webUtils.h
@@ -1,12 +1,17 @@
+#include <epicsString.h>
+
 static std::string getString(void* arg, short type, int len)
 {
+    // use strnlen to avoid embedded nulls
     if (type == menuFtypeSTRING && len == 1)
     {
-        return std::string(*(epicsOldString*)arg, sizeof(epicsOldString));
+        size_t n = epicsStrnLen(*(epicsOldString*)arg, sizeof(epicsOldString));
+        return std::string(*(epicsOldString*)arg, n);
     }
     else if (type == menuFtypeCHAR)
     {
-        return std::string((const char*)arg, len);
+        size_t n = epicsStrnLen((const char*)arg, len);
+        return std::string((const char*)arg, n);
     }
     else
     {

--- a/webgetApp/src/webUtils.h
+++ b/webgetApp/src/webUtils.h
@@ -1,17 +1,16 @@
-
-static const char* getString(void* arg, short type, int len)
+static std::string getString(void* arg, short type, int len)
 {
     if (type == menuFtypeSTRING && len == 1)
     {
-        return *(epicsOldString*)arg;
+        return std::string(*(epicsOldString*)arg, sizeof(epicsOldString));
     }
     else if (type == menuFtypeCHAR)
     {
-        return (const char*)arg;
+        return std::string((const char*)arg, len);
     }
     else
     {
-        return NULL;
+        return "";
     }
 }
 

--- a/webgetApp/src/webget_tests.cc
+++ b/webgetApp/src/webget_tests.cc
@@ -9,16 +9,25 @@
 
 // setup asub record, assumes a,b,c etc fields are consecutive in structure
 // so "b" can be accessed using pointer arithmetic from "a"  
+
 static void setupStringArg(aSubRecord *prec, int index, const char* val)
 {
-    *(&(prec->a) + index * (&(prec->b) - &(prec->a))) = strdup(val);
+	void** arg = &(prec->a) + index * (&(prec->b) - &(prec->a));
+    if (*arg == NULL) {
+        *arg = malloc(sizeof(epicsOldString));
+    }        
+    strncpy((char*)*arg, val, sizeof(epicsOldString));
 	*(&(prec->fta) + index * (&(prec->ftb) - &(prec->fta))) = menuFtypeSTRING;
 	*(&(prec->noa) + index * (&(prec->nob) - &(prec->noa))) = 1;
 }
 
 static void setupWaveformArg(aSubRecord *prec, int index, const char* val)
 {
-    *(&(prec->a) + index * (&(prec->b) - &(prec->a))) = strdup(val);
+	void** arg = &(prec->a) + index * (&(prec->b) - &(prec->a));
+    if (*arg == NULL) {
+        *arg = malloc(1024);
+    }        
+    strncpy((char*)*arg, val, strlen(val));
 	*(&(prec->fta) + index * (&(prec->ftb) - &(prec->fta))) = menuFtypeCHAR;
 	*(&(prec->noa) + index * (&(prec->nob) - &(prec->noa))) = strlen(val);
 }
@@ -29,13 +38,13 @@ namespace {
 		aSubRecord rec;
         memset(&rec, 0, sizeof(rec));
 		rec.ftva = menuFtypeCHAR;
-		rec.nova = 256;
+		rec.nova = 1024;
 		rec.vala = new char[rec.nova];
 		
         // WHEN
-		setupStringArg(&rec, 0, "a");
-		setupStringArg(&rec, 1, "b");
-		setupStringArg(&rec, 2, "c");
+		setupStringArg(&rec, 0, "ahdhdhd");
+		setupWaveformArg(&rec, 1, "hhjkdhfjkasghfas@fhdskagh;jjj@phf");
+		setupStringArg(&rec, 2, "kfkf");
 		setupStringArg(&rec, 3, " ");
 		
 		int ret = webFormURLEncode(&rec);
@@ -43,7 +52,21 @@ namespace {
         // THEN
 		EXPECT_EQ(ret, 0);
 		EXPECT_EQ(rec.neva, strlen((const char*)rec.vala) + 1);
-        EXPECT_STREQ((const char*)rec.vala, "a=b&c=%20");
+        EXPECT_STREQ((const char*)rec.vala, "ahdhdhd=hhjkdhfjkasghfas%40fhdskagh%3Bjjj%40phf&kfkf=%20");
+
+        // WHEN
+		setupStringArg(&rec, 0, "ahdh");
+		setupWaveformArg(&rec, 1, "hhjkdhfj@fhds;a@b");
+		setupStringArg(&rec, 2, "kf");
+		setupStringArg(&rec, 3, "t");
+		
+		ret = webFormURLEncode(&rec);
+
+        // THEN
+		EXPECT_EQ(ret, 0);
+		EXPECT_EQ(rec.neva, strlen((const char*)rec.vala) + 1);
+        EXPECT_STREQ((const char*)rec.vala, "ahdh=hhjkdhfj%40fhds%3Ba%40b&kf=t");
+
     }
     
     TEST(Webget, test_GIVEN_encoded_data_and_test_url_THEN_check_send_ok){

--- a/webgetApp/src/webget_tests.cc
+++ b/webgetApp/src/webget_tests.cc
@@ -19,17 +19,20 @@ static void setupStringArg(aSubRecord *prec, int index, const char* val)
     strncpy((char*)*arg, val, sizeof(epicsOldString));
 	*(&(prec->fta) + index * (&(prec->ftb) - &(prec->fta))) = menuFtypeSTRING;
 	*(&(prec->noa) + index * (&(prec->nob) - &(prec->noa))) = 1;
+	*(&(prec->nea) + index * (&(prec->neb) - &(prec->nea))) = 1;
 }
 
 static void setupWaveformArg(aSubRecord *prec, int index, const char* val)
 {
+    int n = 1024;
 	void** arg = &(prec->a) + index * (&(prec->b) - &(prec->a));
     if (*arg == NULL) {
-        *arg = malloc(1024);
+        *arg = malloc(n);
     }        
     strncpy((char*)*arg, val, strlen(val));
 	*(&(prec->fta) + index * (&(prec->ftb) - &(prec->fta))) = menuFtypeCHAR;
-	*(&(prec->noa) + index * (&(prec->nob) - &(prec->noa))) = strlen(val);
+	*(&(prec->noa) + index * (&(prec->nob) - &(prec->noa))) = n;
+	*(&(prec->nea) + index * (&(prec->neb) - &(prec->nea))) = strlen(val);
 }
 
 namespace {


### PR DESCRIPTION
Updating emails and mobiles with shorter version of the total string ended up leaving stray characters from previous names. Probably not noticed until now as things we likely set once and left alone. 